### PR TITLE
Feature/map config modal

### DIFF
--- a/app/components/maps/Dashboard.js
+++ b/app/components/maps/Dashboard.js
@@ -26,32 +26,31 @@ class Dashboard extends Component {
     if (this.props.config.scenarios.length > 0) {
       scenarioTitle = this.props.config.scenarios[this.props.scenario].title;
     }
-    return {scenarioTitle, categoryTitle, indicatorTitle};
+    return { scenarioTitle, categoryTitle, indicatorTitle };
   }
 
   render() {
     const titles = this.setTitles();
 
     let deleteBtn;
-    const index = this.props.index;
 
     if (this.props.maps.length > 1) {
-      deleteBtn = <Button onClick={() => this.props.deleteMap(this.props.id)} icon="close" style="light" size="small"/>;
+      deleteBtn = <Button onClick={() => this.props.deleteMap(this.props.id)} icon="close" style="light" size="small" />;
     }
 
     const legendConfig = {
-      climate: [{color: '#d6faec', value: 0},
-                {color: '#cff1e1', value: 0.2},
-                {color: '#dde133', value: 0.4},
-                {color: '#e5cf19', value: 0.6},
-                {color: '#a4c504', value: 0.8},
-                {color: '#268434', value: 1}],
-      biodiversity: [{color: '#d2ecfb', value: 0},
-                {color: '#b3ecdd', value: 0.2},
-                {color: '#5faacf', value: 0.4},
-                {color: '#4084cd', value: 0.6},
-                {color: '#4963b8', value: 0.8},
-                {color: '#383e9c', value: 1}]
+      climate: [{ color: '#d6faec', value: 0 },
+                { color: '#cff1e1', value: 0.2 },
+                { color: '#dde133', value: 0.4 },
+                { color: '#e5cf19', value: 0.6 },
+                { color: '#a4c504', value: 0.8 },
+                { color: '#268434', value: 1 }],
+      biodiversity: [{ color: '#d2ecfb', value: 0 },
+                { color: '#b3ecdd', value: 0.2 },
+                { color: '#5faacf', value: 0.4 },
+                { color: '#4084cd', value: 0.6 },
+                { color: '#4963b8', value: 0.8 },
+                { color: '#383e9c', value: 1 }]
     };
 
     return (
@@ -59,7 +58,10 @@ class Dashboard extends Component {
         <div className="dashboard-control">
           <div className="scenario">
             {titles.scenarioTitle}
-            <Button icon="settings" style="none" size="small"/>
+            <Button
+              icon="settings" style="none" size="small"
+              onClick={() => this.props.handleMapConfig(this.props.id)}
+            />
           </div>
           {deleteBtn}
         </div>
@@ -70,7 +72,7 @@ class Dashboard extends Component {
             <ul className="labels">
               {legendConfig[this.props.category].map((element, index) =>
                 <li key={`legend-item-${index}`}>
-                  <span style={{backgroundColor: element.color}}></span>
+                  <span style={{ backgroundColor: element.color }}></span>
                   {element.value}
                 </li>
               )}
@@ -79,15 +81,15 @@ class Dashboard extends Component {
         </div>
         <div className="dashboard-model">
           <label className="control control--checkbox">Climate
-            <input type="checkbox" name="model" value="Model 1"/>
+            <input type="checkbox" name="model" value="Model 1" />
             <div className="control--indicator"></div>
           </label>
           <label className="control control--checkbox">Biodiversity
-            <input type="checkbox" name="model" value="Model 2"/>
+            <input type="checkbox" name="model" value="Model 2" />
             <div className="control--indicator"></div>
           </label>
           <label className="control control--checkbox">Precipitation
-            <input type="checkbox" name="model" value="Model 2"/>
+            <input type="checkbox" name="model" value="Model 2" />
             <div className="control--indicator"></div>
           </label>
         </div>
@@ -104,8 +106,9 @@ Dashboard.propTypes = {
   category: React.PropTypes.string,
   indicator: React.PropTypes.string,
   showDeleteBtn: React.PropTypes.bool,
-  onRemoveClick: React.PropTypes.func,
+  deleteMap: React.PropTypes.func,
   onMapDrag: React.PropTypes.func,
+  handleMapConfig: React.PropTypes.func,
   config: React.PropTypes.object,
   maps: React.PropTypes.array
 };

--- a/app/components/maps/Map.js
+++ b/app/components/maps/Map.js
@@ -4,19 +4,9 @@ import Dashboard from 'containers/maps/DashboardContainer';
 
 class Map extends React.Component {
   render() {
-    const {id} = {...this.props};
+    const { id } = this.props;
     return (
-      <div className="scenario-wrapper">
-        <Dashboard
-          id={this.props.id}
-          scenario={this.props.scenario}
-          category={this.props.category}
-          indicator={this.props.indicator}
-          maps={this.props.maps}
-          deleteMap={this.props.deleteMap}
-          />
-        <div id={`map${id}`} className="c-map"></div>
-      </div>
+      <div id={`map${id}`} className="c-map"></div>
    );
   }
 

--- a/app/components/maps/MapsList.js
+++ b/app/components/maps/MapsList.js
@@ -1,36 +1,46 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Map from './Map';
+import Dashboard from 'containers/maps/DashboardContainer';
 
-class MapsList extends Component {
-  render() {
-    const length = this.props.maps.length;
-    const mapClasses = [
-      ['-full'],
-      ['-horizontal', '-horizontal'],
-      ['-wide', '-wide', '-narrow'],
-      ['-quarter', '-quarter', '-quarter', '-quarter']
-    ];
+function MapsList(props) {
+  const length = props.maps.length;
+  const mapClasses = [
+    ['-full'],
+    ['-horizontal', '-horizontal'],
+    ['-wide', '-wide', '-narrow'],
+    ['-quarter', '-quarter', '-quarter', '-quarter']
+  ];
 
-    return (
-      <div className="l-maps-container">
-        {this.props.maps.map((map, index) =>
-          <div className={`c-maps-list ${mapClasses[length - 1][index]}`} key={`map-${index}`}>
+  return (
+    <div className="l-maps-container">
+      {props.maps.map((map, index) =>
+        <div className={`c-maps-list ${mapClasses[length - 1][index]}`} key={`map-${index}`}>
+          <div className="scenario-wrapper">
+            <Dashboard
+              id={`${index}`}
+              scenario={map.scenario}
+              category={map.category}
+              indicator={map.indicator}
+              maps={props.maps}
+              deleteMap={props.deleteMap}
+              handleMapConfig={props.handleMapConfig}
+            />
             <Map
               id={`${index}`}
               scenario={map.scenario}
               category={map.category}
               indicator={map.indicator}
-              latLng={this.props.latLng}
-              zoom={this.props.zoom}
-              onMapDrag={this.props.onMapDrag}
-              maps={this.props.maps}
-              deleteMap={this.props.deleteMap}
-              />
+              latLng={props.latLng}
+              zoom={props.zoom}
+              onMapDrag={props.onMapDrag}
+              maps={props.maps}
+              deleteMap={props.deleteMap}
+            />
           </div>
-        )}
-      </div>
-    );
-  }
+        </div>
+      )}
+    </div>
+  );
 }
 
 MapsList.contextTypes = {
@@ -42,7 +52,8 @@ MapsList.propTypes = {
   latLng: React.PropTypes.object,
   zoom: React.PropTypes.number,
   onMapDrag: React.PropTypes.func,
-  deleteMap: React.PropTypes.func
+  deleteMap: React.PropTypes.func,
+  handleMapConfig: React.PropTypes.func
 };
 
 export default MapsList;

--- a/app/components/modals/MapsModal.js
+++ b/app/components/modals/MapsModal.js
@@ -31,7 +31,11 @@ class MapsModal extends Component {
     });
   }
 
-  setMapState(newObj) {
+  setMapState(map) {
+    const newObj = Object.assign({}, map, {});
+    if (this.props.mapSelectedId) {
+      newObj.id = this.props.mapSelectedId;
+    }
     this.props.setMapState(newObj);
     this.props.onSetMapModal(false);
   }

--- a/app/components/modals/MapsModal.js
+++ b/app/components/modals/MapsModal.js
@@ -12,9 +12,9 @@ class MapsModal extends Component {
       searchable: false,
       clearable: false,
       /* initial state options for modal */
-      selectedScenario: this.props.initialScenario,
-      selectedCategory: this.props.initialCategory,
-      selectedIndicator: this.props.initialIndicator
+      selectedScenario: this.props.mapConfigData.scenario,
+      selectedCategory: this.props.mapConfigData.category,
+      selectedIndicator: this.props.mapConfigData.indicator
     };
     this.handleScenarioChange = this.handleScenarioChange.bind(this);
     this.handleCategory = this.handleCategory.bind(this);
@@ -23,30 +23,11 @@ class MapsModal extends Component {
     this.setIndicators = this.setIndicators.bind(this);
   }
 
-  handleScenarioChange(newValue) {
-    this.setState({
-      selectedScenario: newValue
-    });
-  }
-
-  handleCategory(newValue) {
-    this.setState({
-      selectedCategory: newValue.slug,
-      selectedIndicator: null
-    });
-  }
-
-  handleIndicator(newValue) {
-    this.setState({
-      selectedIndicator: newValue.slug
-    });
-  }
-
   componentWillReceiveProps(nextProps) {
     this.setState({
-      selectedScenario: nextProps.initialScenario,
-      selectedCategory: nextProps.initialCategory,
-      selectedIndicator: nextProps.initialIndicator
+      selectedScenario: nextProps.mapConfigData.scenario,
+      selectedCategory: nextProps.mapConfigData.category,
+      selectedIndicator: nextProps.mapConfigData.indicato
     });
   }
 
@@ -74,7 +55,26 @@ class MapsModal extends Component {
       category: this.state.selectedCategory,
       indicator: indicatorValue
     };
-    return {activeIndicators, indicatorValue, mapState};
+    return { activeIndicators, indicatorValue, mapState };
+  }
+
+  handleScenarioChange(newValue) {
+    this.setState({
+      selectedScenario: newValue
+    });
+  }
+
+  handleCategory(newValue) {
+    this.setState({
+      selectedCategory: newValue.slug,
+      selectedIndicator: null
+    });
+  }
+
+  handleIndicator(newValue) {
+    this.setState({
+      selectedIndicator: newValue.slug
+    });
   }
 
   render() {
@@ -87,7 +87,7 @@ class MapsModal extends Component {
           modalOpen={this.props.mapModalOpen}
           onSetModal={this.props.onSetMapModal}
           btnStyle="dark"
-          >
+        >
           <div className="title">
             Add Scenario
           </div>
@@ -101,7 +101,7 @@ class MapsModal extends Component {
                 value={scenario.id}
                 checked={scenario.id === this.state.selectedScenario}
                 onChange={() => this.handleScenarioChange(scenario.id)}
-                />
+              />
               <label htmlFor={`scenario-${index}`}>
                 {scenario.title}
               </label>
@@ -123,7 +123,7 @@ class MapsModal extends Component {
               searchable={this.state.searchable}
               labelKey="title"
               valueKey="slug"
-              />
+            />
             <Select
               options={newIndicators.activeIndicators}
               clearable={this.state.clearable}
@@ -133,9 +133,12 @@ class MapsModal extends Component {
               searchable={this.state.searchable}
               labelKey="title"
               valueKey="slug"
-              />
+            />
           </div>
-          <Button onClick={() => this.setMapState(newIndicators.mapState)} icon="arrow" style="primary" size="large" text="explore" color="dark"/>
+          <Button
+            onClick={() => this.setMapState(newIndicators.mapState)}
+            icon="arrow" style="primary" size="large" text="explore" color="dark"
+          />
         </Modal>
       </div>
     );
@@ -164,17 +167,13 @@ MapsModal.propTypes = {
   **/
   indicators: React.PropTypes.array,
   /**
-  * Initial value passed to modal when opened
+  * Data of the map config
   **/
-  initialScenario: React.PropTypes.string,
-  /**
-  * Initial value passed to modal when opened
-  **/
-  initialCategory: React.PropTypes.string,
-  /**
-  * Initial value passed to modal when opened
-  **/
-  initialIndicator: React.PropTypes.string,
+  mapConfigData: React.PropTypes.shape({
+    scenario: React.PropTypes.string,
+    category: React.PropTypes.string,
+    indicator: React.PropTypes.string
+  }),
   /**
   * Function to supply setMap action to Maps page
   **/

--- a/app/components/pages/MapsPage.js
+++ b/app/components/pages/MapsPage.js
@@ -66,6 +66,7 @@ class MapsPage extends React.Component {
           deleteMap={this.props.deleteMap}
         />
         <MapsModal
+          mapSelectedId={this.state.mapSelectedId}
           mapModalOpen={this.state.mapModalOpen}
           onSetMapModal={this.handleSetMapModal}
           scenarios={this.props.scenarios}

--- a/app/components/pages/MapsPage.js
+++ b/app/components/pages/MapsPage.js
@@ -11,6 +11,11 @@ class MapsPage extends React.Component {
       mapSelectedId: null
     };
     this.handleSetMapModal = this.handleSetMapModal.bind(this);
+    this.defaultMapConfig = {
+      scenario: '0',
+      category: 'climate',
+      indicator: 'avg-precipitation'
+    };
   }
 
   componentDidMount() {
@@ -52,7 +57,7 @@ class MapsPage extends React.Component {
     const mapConfigData = this.state.mapSelectedId
       ? this.props.maps[this.state.mapSelectedId]
       // default map config
-      : { scenario: '0', category: 'climate', indicator: 'avg-precipitation' };
+      : this.defaultMapConfig;
     return (
       <div className="-dark">
         <div className="c-add-map">

--- a/app/components/pages/MapsPage.js
+++ b/app/components/pages/MapsPage.js
@@ -8,21 +8,13 @@ class MapsPage extends React.Component {
     super(props);
     this.state = {
       mapModalOpen: false,
-      initialScenario: '0',
-      initialCategory: 'climate',
-      initialIndicator: 'avg-precipitation'
+      mapSelectedId: null
     };
     this.handleSetMapModal = this.handleSetMapModal.bind(this);
   }
 
-  handleSetMapModal(status) {
-    this.setState({
-      mapModalOpen: status
-    });
-  }
-
   componentDidMount() {
-    const {query} = this.context.location;
+    const { query } = this.context.location;
 
     if (query && query.maps) {
       this.props.setParamsFromURL(query.maps);
@@ -37,12 +29,30 @@ class MapsPage extends React.Component {
     }
   }
 
+  setMapConfigModal(id) {
+    this.setState({
+      mapModalOpen: true,
+      mapSelectedId: id
+    });
+  }
+
+  handleSetMapModal(status) {
+    this.setState({
+      mapModalOpen: status
+    });
+  }
+
   render() {
     let addBtn;
     const mapsList = this.props.maps;
     if (mapsList.length < 4) {
-      addBtn = <Button icon="plus-big" style="primary" size="large" onClick={() => this.handleSetMapModal(true)}/>;
+      addBtn = <Button icon="plus-big" style="primary" size="large" onClick={() => this.setMapConfigModal(null)} />;
     }
+
+    const mapConfigData = this.state.mapSelectedId
+      ? this.props.maps[this.state.mapSelectedId]
+      // default map config
+      : { scenario: '0', category: 'climate', indicator: 'avg-precipitation' };
     return (
       <div className="-dark">
         <div className="c-add-map">
@@ -52,19 +62,18 @@ class MapsPage extends React.Component {
           maps={this.props.maps}
           latLng={this.props.latLng}
           zoom={this.props.zoom}
+          handleMapConfig={(id) => this.setMapConfigModal(id)}
           deleteMap={this.props.deleteMap}
-          />
+        />
         <MapsModal
           mapModalOpen={this.state.mapModalOpen}
           onSetMapModal={this.handleSetMapModal}
           scenarios={this.props.scenarios}
           categories={this.props.categories}
           indicators={this.props.indicators}
-          initialScenario={this.state.initialScenario}
-          initialCategory={this.state.initialCategory}
-          initialIndicator={this.state.initialIndicator}
+          mapConfigData={mapConfigData}
           setMapState={this.props.setMap}
-          />
+        />
       </div>
     );
   }


### PR DESCRIPTION
Get the dashboard component out of the map component to be used easily for edit one so now you can edit the config of each map.

Instead of 3 strings param to the map modal I use an [object](https://github.com/Vizzuality/helix-scope/compare/develop...feature/map-config-modal?expand=1#diff-a9889150e9aad976a7152433c9425e45R176) with the config.

Also fix lints errors of the files I used.