### PR TITLE
Replace npmcdn.com with unpkg.com

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -25,7 +25,7 @@
     <meta name="theme-color" content="#ffffff">
 
     <link rel="stylesheet" href="https://unpkg.com/leaflet@0.7.7/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://npmcdn.com/react-select/dist/react-select.css">
+    <link rel="stylesheet" href="https://unpkg.com/react-select/dist/react-select.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.3.15/slick.css" />
   </head>
 


### PR DESCRIPTION
To avoid potential naming conflicts with npm, npmcdn.com is being renamed to unpkg.com.