### PR TITLE
Fix update layer on map changes

### DIFF
--- a/app/components/maps/Map.js
+++ b/app/components/maps/Map.js
@@ -182,6 +182,7 @@ class Map extends React.Component {
   updateLayer(layer) {
     if (this.layer) {
       this.layer.setUrl(layer.tileUrl);
+      this.currentLayer = layer.slug;
     } else {
       this.layer = L.tileLayer(layer.tileUrl, { noWrap: true }).setZIndex(2);
       this.layer.on('load', this.onTileLoaded);


### PR DESCRIPTION
Doesn't reload the layers unnecessarily after map changes as drag so save the currentLayer on update.