### PR TITLE
Fix share url copy

### DIFF
--- a/app/components/modals/ShareModal.js
+++ b/app/components/modals/ShareModal.js
@@ -14,7 +14,7 @@ class ShareModal extends Component {
 
   handleCopyClick() {
     try {
-      this.url.urlInput.select();
+      this.url.select();
       const isEnabled = document.queryCommandEnabled('copy');
       const successful = document.execCommand('copy');
 


### PR DESCRIPTION
The share url copy didn't work because of a wrong name in the ref.