### PR TITLE
Bug/empty charts

### DIFF
--- a/app/components/common/Chart.js
+++ b/app/components/common/Chart.js
@@ -6,23 +6,35 @@ import { getSeasonTextById } from 'constants/season';
 class Chart extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      noData: false
+    };
     this.data = {};
     this.timer = null;
   }
 
   componentDidMount() {
-    this.onPageResize = () => {
-      this.debounceDraw();
-    };
-    window.addEventListener('resize', this.onPageResize);
+    if (this.props.data.data && this.props.data.data.length) {
+      this.onPageResize = () => {
+        this.debounceDraw();
+      };
+      window.addEventListener('resize', this.onPageResize);
 
-    this.data = this.getParsedData(this.props.data);
-    this.drawChart();
+      this.data = this.getParsedData(this.props.data);
+      this.drawChart();
+    } else {
+      this.setnoDataState(true);
+    }
   }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.onPageResize);
+  }
+
+  setnoDataState(state) {
+    this.setState({
+      noData: state
+    });
   }
 
   getBucketsColor(category) {
@@ -195,12 +207,17 @@ class Chart extends React.Component {
     const downloadLink = `${ENDPOINT_SQL}?q=SELECT * FROM ${this.props.data.table_name} WHERE iso='${this.props.iso}'&format=csv`;
     return (
       <div className="c-chart">
-        <a className="icon" href={downloadLink} target="_blank">
-          <svg width="10" height="10" viewBox="0 0 16 16"><title>Download</title><path d="M12.307 16H3.693a1 1 0 0 1-.936-.649L0 8h16l-2.757 7.351a1 1 0 0 1-.936.649zM4 3l4 4 4-4h-2V0H6v3H4z" fillRule="evenodd" /></svg>
-        </a>
+        {!this.state.noData &&
+          <a className="icon" href={downloadLink} target="_blank">
+            <svg width="10" height="10" viewBox="0 0 16 16"><title>Download</title><path d="M12.307 16H3.693a1 1 0 0 1-.936-.649L0 8h16l-2.757 7.351a1 1 0 0 1-.936.649zM4 3l4 4 4-4h-2V0H6v3H4z" fillRule="evenodd" /></svg>
+          </a>
+        }
         <div className="subtitle">{this.props.data.category}</div>
         <div className="title">{this.props.data.indicator}</div>
-        <div className="chart" ref={ref => (this.chart = ref)}></div>
+        {this.state.noData
+          ? <div className="content subtitle">There is no data for this selector</div>
+          : <div className="chart" ref={ref => (this.chart = ref)}></div>
+        }
       </div>
     );
   }

--- a/app/components/common/Chart.js
+++ b/app/components/common/Chart.js
@@ -215,7 +215,7 @@ class Chart extends React.Component {
         <div className="subtitle">{this.props.data.category}</div>
         <div className="title">{this.props.data.indicator}</div>
         {this.state.noData
-          ? <div className="content subtitle">There is no data for this selector</div>
+          ? <div className="content subtitle">There is no data for this indicator</div>
           : <div className="chart" ref={ref => (this.chart = ref)}></div>
         }
       </div>

--- a/app/styles/components/common/c-chart.pcss
+++ b/app/styles/components/common/c-chart.pcss
@@ -42,6 +42,13 @@
     margin: $margin-small 0;
   }
 
+  > .content {
+    min-height: 350px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   > .chart {
     height: 350px;
 

--- a/app/styles/components/common/c-sticky.pcss
+++ b/app/styles/components/common/c-sticky.pcss
@@ -1,4 +1,5 @@
 .c-sticky {
+  position: relative;
   padding-top: 1rem;
   padding-bottom: 1rem;
   z-index: 2;


### PR DESCRIPTION
Add text when chart data is empty.

![image](https://cloud.githubusercontent.com/assets/10500650/19263004/52b8042a-8f9a-11e6-9e50-79e5e6e349a1.png)

Also fix the country selector options:
![image](https://cloud.githubusercontent.com/assets/10500650/19263036/83b53a98-8f9a-11e6-8e31-e15adfdb01f9.png)
vs 
![image](https://cloud.githubusercontent.com/assets/10500650/19263023/772d6cc8-8f9a-11e6-961e-958c92902efd.png)

