### PR TITLE
Fix url in share component

### DIFF
--- a/app/components/modals/ShareModal.js
+++ b/app/components/modals/ShareModal.js
@@ -58,19 +58,19 @@ class ShareModal extends Component {
             Copy this URL to Share
           </div>
           <div className="actions">
-            <input ref={ref => (this.url = ref)} defaultValue={`http://helixscope.org${this.props.shareUrl}`} className="c-input url" />
+            <input ref={ref => (this.url = ref)} defaultValue={this.props.shareUrl} className="c-input url" />
             <Button onClick={this.handleCopyClick} icon="arrow" style="primary" size="large" text={btnText} color="dark" position="copy-link" />
           </div>
           <div className="copy-text">
             {copyText}
           </div>
           <div className="share-links">
-            <a href={`http://www.facebook.com/sharer/sharer.php?u=http://helixscope.org${this.props.shareUrl}`} className="c-btn btn-link" target="_blank" rel="noopener noreferrer">
+            <a href={`http://www.facebook.com/sharer/sharer.php?u=${this.props.shareUrl}`} className="c-btn btn-link" target="_blank" rel="noopener noreferrer">
               <svg className={'btn-icon icon-facebook -none -size-small'}>
                 <use xlinkHref={'#icon-facebook'}></use>
               </svg>
             </a>
-            <a href={`https://twitter.com/share?url=http://helixscope.org${this.props.shareUrl}`} className="c-btn btn-link" target="_blank" rel="noopener noreferrer">
+            <a href={`https://twitter.com/share?url=${this.props.shareUrl}`} className="c-btn btn-link" target="_blank" rel="noopener noreferrer">
               <svg className={'btn-icon icon-twitter -none -size-small'}>
                 <use xlinkHref={'#icon-twitter'}></use>
               </svg>

--- a/app/components/pages/ContainerPage.js
+++ b/app/components/pages/ContainerPage.js
@@ -28,7 +28,7 @@ class ContainerPage extends React.Component {
           title="Share"
           shareModalOpen={this.props.shareModalOpen}
           setShareModal={() => this.props.setShareModal(false)}
-          shareUrl={this.props.location.pathname}
+          shareUrl={window.location.href}
         />
         <MenuModal
           menuModalOpen={this.props.menuModalOpen}


### PR DESCRIPTION
Use `window.location.href` to the share component instead of generate the url.