### PR TITLE
Move add map button and fix zoom button

### DIFF
--- a/app/styles/components/maps/c-add-modal.pcss
+++ b/app/styles/components/maps/c-add-modal.pcss
@@ -111,7 +111,7 @@
 
 .c-add-map {
   position: absolute;
-  top: 40px;
-  right: 100px;
+  bottom: 40px;
+  right: 30px;
   z-index: 1003;
 }

--- a/app/styles/components/maps/c-map.pcss
+++ b/app/styles/components/maps/c-map.pcss
@@ -38,6 +38,11 @@
   margin-top: 10px;
   height: 28px;
   width: 28px;
+
+  &:hover {
+    width: 28px;
+    height: 28px;
+  }
 }
 
 .map {


### PR DESCRIPTION
Move the add map button to the button right corner.
Fix the zoom buttons size on hover.