### PR TITLE
Fix/legend issues

### DIFF
--- a/app/components/maps/Dashboard.js
+++ b/app/components/maps/Dashboard.js
@@ -17,7 +17,7 @@ function Dashboard(props) {
         <div className="scenario">
           {props.mapData.scenario.name}
           <Button
-            icon="settings" style="none" size="small"
+            icon="settings" style="none" size="small" position="right"
             onClick={() => props.handleMapConfig(props.mapData.id)}
           />
         </div>

--- a/app/components/maps/Legend.js
+++ b/app/components/maps/Legend.js
@@ -16,7 +16,7 @@ class Legend extends React.Component {
       return <div></div>;
     }
 
-    const gradient = `linear-gradient(to right, ${percentages.map((p, n) => `${colors[n]} ${p}`).join(', ')})`;
+    const gradient = `linear-gradient(to left, ${percentages.map((p, n) => `${colors[n]} ${p}`).join(', ')})`;
     return (
       <div className="c-legend">
         <ul className="labels">

--- a/app/styles/components/maps/c-dashboard.pcss
+++ b/app/styles/components/maps/c-dashboard.pcss
@@ -28,7 +28,7 @@
       flex-direction: row;
       align-items: center;
       justify-content: space-between;
-      width: 80px;
+      width: 100%;
     }
   }
 

--- a/app/styles/components/maps/c-maps-list.pcss
+++ b/app/styles/components/maps/c-maps-list.pcss
@@ -39,5 +39,6 @@
 
   > .scenario-wrapper {
     height: 100%;
+    position: relative;
   }
 }


### PR DESCRIPTION
Few fixes here:

1. Legend component for any bottom map was not showing up correctly.
2. Styling change for scenario name to make the component smaller.
from ![image](https://user-images.githubusercontent.com/1286444/35059104-5819f44a-fbba-11e7-9b5a-b7f138c48a0d.png) to 
![image](https://user-images.githubusercontent.com/1286444/35059134-76ab3900-fbba-11e7-99a6-72774f26d7a9.png) 
![image](https://user-images.githubusercontent.com/1286444/35059160-8b20c0c6-fbba-11e7-9b48-50f09c887b17.png)
3. Gradient bar on the legend was inverted 
changed 
![image](https://user-images.githubusercontent.com/1286444/35059369-32c7f312-fbbb-11e7-9d38-25cb71bdc731.png) to
 ![image](https://user-images.githubusercontent.com/1286444/35059320-07d52b8e-fbbb-11e7-88e1-4163cdf269c1.png)






**[Story link](https://www.pivotaltracker.com/story/show/134082645)**