### PR TITLE
remove extranous text for scenario selection buttons

### DIFF
--- a/app/components/modals/MapsModal.js
+++ b/app/components/modals/MapsModal.js
@@ -105,7 +105,7 @@ class MapsModal extends Component {
                 onChange={() => this.handleScenarioChange(scenario)}
               />
               <label htmlFor={`scenario-${index}`}>
-                {scenario.name}
+                {scenario.short_name.replace('+', '')}
               </label>
             </div>
           )}


### PR DESCRIPTION
Removing extraneous text for scenario buttons to comply with designs.

![image](https://user-images.githubusercontent.com/1286444/35289668-49915d5c-0068-11e8-8ce0-d01d49410487.png)
