### PR TITLE
Feature/map view link, fixing maps page routing issues and precipitation color scheme

### DIFF
--- a/app/actions/maps.js
+++ b/app/actions/maps.js
@@ -7,6 +7,7 @@ import {
   MAP_NUMBER_BUCKETS,
   MAX_MAPS
 } from 'constants/map';
+import { mapListToQueryString } from 'utils/maps';
 
 export const MAP_UPDATE_DATA = 'MAP_UPDATE_DATA';
 export const MAP_UPDATE_PAN = 'MAP_UPDATE_PAN';
@@ -76,19 +77,8 @@ export function updateURL() {
   return (dispatch, state) => {
     const maps = state().maps;
     const params = `${maps.latLng.lat}/${maps.latLng.lng}/${maps.zoom}`;
-    let query = '';
+    const query = mapListToQueryString(maps.mapsList);
 
-    if (maps.mapsList.length) {
-      query = '?maps=';
-
-      maps.mapsList.forEach((map, index) => {
-        query += `${map.scenario.slug},${map.category.slug},${map.indicator.slug}`;
-
-        if (index < maps.mapsList.length - 1) {
-          query += '/';
-        }
-      });
-    }
     dispatch(push(`/global-scenarios/${params}${query}`));
   };
 }
@@ -106,7 +96,7 @@ export function setMap(map) {
         elem.id === map.id
       ));
       if (selectedMap) {
-        selectedMap = Object.assign(selectedMap, map, { bucket: [] });
+        selectedMap = Object.assign(selectedMap, map, { bucket: null });
       } else {
         const newMap = map;
         newMap.id = uuid();

--- a/app/components/charts/DisplayCharts.js
+++ b/app/components/charts/DisplayCharts.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Select from 'react-select';
 import get from 'lodash/get';
+import { Link } from 'react-router';
 
 import InterQuartileRangeChart from 'containers/charts/InterQuartileRange';
 import RegularBarChart from 'containers/charts/RegularBar';
@@ -112,6 +113,7 @@ class DisplayCharts extends Component {
           ) : (
              selectedChart.label
           )}
+          {selectedChart.mapViewLink && <Link to={selectedChart.mapViewLink}>MAP VIEW</Link>}
           {availableMeasurements && (
             <MeasureSelector
               measure={selectedMeasure}

--- a/app/components/charts/DisplayCharts.js
+++ b/app/components/charts/DisplayCharts.js
@@ -99,21 +99,25 @@ class DisplayCharts extends Component {
     return (
       <div className="c-display-chart">
         <div className="header">
-          {charts.length > 1 ? (
-            <Select
-              className="c-react-select -white"
-              options={charts}
-              value={selectedChart}
-              onChange={this.handleChartChange}
-              clearable={false}
-              searchable={false}
-              labelKey="label"
-              valueKey="label"
-            />
-          ) : (
-             selectedChart.label
-          )}
-          {selectedChart.mapViewLink && <Link to={selectedChart.mapViewLink}>MAP VIEW</Link>}
+          <div className="title">
+            {charts.length > 1 ? (
+              <Select
+                className="c-react-select -white"
+                options={charts}
+                value={selectedChart}
+                onChange={this.handleChartChange}
+                clearable={false}
+                searchable={false}
+                labelKey="label"
+                valueKey="label"
+              />
+            ) : (
+               selectedChart.label
+            )}
+            {selectedChart.mapViewLink && (
+              <Link className="map-view-link" to={selectedChart.mapViewLink}>MAP VIEW</Link>
+            )}
+          </div>
           {availableMeasurements && (
             <MeasureSelector
               measure={selectedMeasure}

--- a/app/components/maps/Legend.js
+++ b/app/components/maps/Legend.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { formatSI } from 'utils/format';
-import { categoryColorScheme } from 'constants/colors';
+import { getColorScheme } from 'utils/colors';
 import {
   MAP_NUMBER_BUCKETS,
   MAP_LEGEND_MAX_TICKS
@@ -28,14 +28,13 @@ class Legend extends React.Component {
 
   render() {
     const { mapData } = this.props;
-    const colors = categoryColorScheme[mapData.category.slug](MAP_NUMBER_BUCKETS);
+    const colors = getColorScheme(mapData.category.slug, mapData.indicator.slug, MAP_NUMBER_BUCKETS);
 
     if (!mapData || !mapData.bucket || !mapData.bucket.length) {
       return <div></div>;
     }
 
     const colorWidth = 100 / MAP_NUMBER_BUCKETS;
-    // const background = `linear-gradient(to right, ${colors.map((c, index) => `${c} ${colorWidth * index}%`).join(', ')})`; // gradient
     const background = `linear-gradient(to right, ${colors.map((c, index) => `${c} ${colorWidth * index}%, ${c} ${colorWidth * (index + 1)}%`).join(', ')})`;
 
     const rangeStyle = {

--- a/app/components/maps/Map.js
+++ b/app/components/maps/Map.js
@@ -66,9 +66,6 @@ class Map extends React.Component {
       props.mapConfig.zoom !== this.props.mapConfig.zoom);
     const bucketChanged = JSON.stringify(props.mapData.bucket) !== JSON.stringify(this.props.mapData.bucket);
     const newBucketEmpty = !Array.isArray(props.mapData.bucket) || !props.mapData.bucket.length;
-    const newBucketLoaded = (!this.bucket && this.state.loading) &&
-          props.mapData.bucket &&
-          props.mapData.bucket.length;
 
     if (paramsChanged) {
       this.map.panTo([props.mapConfig.latLng.lat, props.mapConfig.latLng.lng], {
@@ -80,7 +77,6 @@ class Map extends React.Component {
     }
 
     if (!props.mapData.bucket && bucketChanged) {
-      console.log('reloading buckets');
       this.bucket = props.mapData.bucket;
       this.setLoadingStatus(true);
       props.getMapBuckets(props.mapData);
@@ -91,8 +87,7 @@ class Map extends React.Component {
       this.updateLayer(props.mapData.layer);
     }
 
-    if (newBucketLoaded ||
-        (bucketChanged && !newBucketEmpty)) {
+    if (bucketChanged && !newBucketEmpty) {
       this.getLayer(props.mapData);
     }
 
@@ -226,6 +221,8 @@ class Map extends React.Component {
   }
 
   getLayer(mapData) {
+    this.setLoadingStatus(true);
+
     this.bucket = mapData.bucket;
     this.generateCartoCSS(mapData);
     const layer = this.getLayerData({

--- a/app/components/maps/Map.js
+++ b/app/components/maps/Map.js
@@ -21,9 +21,7 @@ import { getColorScheme } from 'utils/colors';
 class Map extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      loading: true
-    };
+    this.state = { tileLoading: false };
     this.onTileLoaded = this.onTileLoaded.bind(this);
   }
 
@@ -78,7 +76,6 @@ class Map extends React.Component {
 
     if (!props.mapData.bucket && bucketChanged) {
       this.bucket = props.mapData.bucket;
-      this.setLoadingStatus(true);
       props.getMapBuckets(props.mapData);
     }
 
@@ -101,7 +98,8 @@ class Map extends React.Component {
       props.mapData.scenario !== this.props.mapData.scenario ||
       props.mapData.category !== this.props.mapData.category ||
       props.mapData.indicator !== this.props.mapData.indicator ||
-      state.loading !== this.state.loading;
+      props.mapData.bucketLoading !== this.props.mapData.bucketLoading ||
+      state.tileLoading !== this.state.tileLoading;
 
     return shouldUpdate;
   }
@@ -111,13 +109,11 @@ class Map extends React.Component {
   }
 
   onTileLoaded() {
-    this.setLoadingStatus(false);
+    this.setTileLoadingStatus(false);
   }
 
-  setLoadingStatus(status) {
-    this.setState({
-      loading: status
-    });
+  setTileLoadingStatus(status) {
+    this.setState({ tileLoading: status });
   }
 
   setListeners() {
@@ -221,7 +217,7 @@ class Map extends React.Component {
   }
 
   getLayer(mapData) {
-    this.setLoadingStatus(true);
+    this.setTileLoadingStatus(true);
 
     this.bucket = mapData.bucket;
     this.generateCartoCSS(mapData);
@@ -329,11 +325,12 @@ class Map extends React.Component {
   }
 
   render() {
-    const { id } = this.props.mapData;
+    const { id, bucketLoading } = this.props.mapData;
+    const isLoading = this.state.tileLoading || bucketLoading;
     return (
       <div className="c-map">
         <div id={`map${id}`}></div>
-        {this.state.loading && <LoadingSpinner inner />}
+        {isLoading && <LoadingSpinner inner />}
       </div>
     );
   }
@@ -346,7 +343,8 @@ Map.propTypes = {
     scenario: React.PropTypes.object,
     category: React.PropTypes.object,
     indicator: React.PropTypes.object,
-    bucket: React.PropTypes.array
+    bucket: React.PropTypes.array,
+    bucketLoading: React.PropTypes.bool
   }).isRequired,
   mapConfig: React.PropTypes.shape({
     latLng: React.PropTypes.object,

--- a/app/components/maps/Map.js
+++ b/app/components/maps/Map.js
@@ -22,7 +22,7 @@ class Map extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      loading: true
+      loading: false
     };
     this.onTileLoaded = this.onTileLoaded.bind(this);
   }
@@ -65,7 +65,10 @@ class Map extends React.Component {
       props.mapConfig.latLng.lng !== this.props.mapConfig.latLng.lng ||
       props.mapConfig.zoom !== this.props.mapConfig.zoom);
     const bucketChanged = JSON.stringify(props.mapData.bucket) !== JSON.stringify(this.bucket);
-    const bucketEmpty = props.mapData.bucket && !props.mapData.bucket.length;
+    const newBucketEmpty = !Array.isArray(props.mapData.bucket) || !props.mapData.bucket.length;
+    const newBucketLoaded = (!this.bucket && this.state.loading) &&
+          props.mapData.bucket &&
+          props.mapData.bucket.length;
 
     if (paramsChanged) {
       this.map.panTo([props.mapConfig.latLng.lat, props.mapConfig.latLng.lng], {
@@ -76,7 +79,7 @@ class Map extends React.Component {
       this.invalidateSize();
     }
 
-    if (bucketChanged && bucketEmpty) {
+    if (!this.state.loading && !props.mapData.bucket && (!this.bucket || bucketChanged)) {
       this.bucket = props.mapData.bucket;
       this.setLoadingStatus(true);
       props.getMapBuckets(props.mapData);
@@ -87,8 +90,8 @@ class Map extends React.Component {
       this.updateLayer(props.mapData.layer);
     }
 
-    if ((!this.bucket && props.mapData.bucket) ||
-        (bucketChanged && !bucketEmpty)) {
+    if (newBucketLoaded ||
+        (bucketChanged && !newBucketEmpty)) {
       this.getLayer(props.mapData);
     }
 

--- a/app/components/maps/Map.js
+++ b/app/components/maps/Map.js
@@ -22,7 +22,7 @@ class Map extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      loading: false
+      loading: true
     };
     this.onTileLoaded = this.onTileLoaded.bind(this);
   }
@@ -64,7 +64,7 @@ class Map extends React.Component {
       props.mapConfig.latLng.lat !== this.props.mapConfig.latLng.lat ||
       props.mapConfig.latLng.lng !== this.props.mapConfig.latLng.lng ||
       props.mapConfig.zoom !== this.props.mapConfig.zoom);
-    const bucketChanged = JSON.stringify(props.mapData.bucket) !== JSON.stringify(this.bucket);
+    const bucketChanged = JSON.stringify(props.mapData.bucket) !== JSON.stringify(this.props.mapData.bucket);
     const newBucketEmpty = !Array.isArray(props.mapData.bucket) || !props.mapData.bucket.length;
     const newBucketLoaded = (!this.bucket && this.state.loading) &&
           props.mapData.bucket &&
@@ -79,7 +79,8 @@ class Map extends React.Component {
       this.invalidateSize();
     }
 
-    if (!this.state.loading && !props.mapData.bucket && (!this.bucket || bucketChanged)) {
+    if (!props.mapData.bucket && bucketChanged) {
+      console.log('reloading buckets');
       this.bucket = props.mapData.bucket;
       this.setLoadingStatus(true);
       props.getMapBuckets(props.mapData);

--- a/app/components/maps/Map.js
+++ b/app/components/maps/Map.js
@@ -16,7 +16,7 @@ import {
   MAP_LAYER_SPEC,
   MAP_VECTOR_CSS
 } from 'constants/map';
-import { categoryColorScheme } from 'constants/colors';
+import { getColorScheme } from 'utils/colors';
 
 class Map extends React.Component {
   constructor(props) {
@@ -303,8 +303,8 @@ class Map extends React.Component {
     }
   }
 
-  generateCartoCSS(mapData) {
-    const colorscheme = [...categoryColorScheme[mapData.category.slug](MAP_NUMBER_BUCKETS)].reverse();
+  generateCartoCSS({ category, indicator }) {
+    const colorscheme = [...getColorScheme(category.slug, indicator.slug, MAP_NUMBER_BUCKETS)].reverse();
     const bucketList = [...this.bucket].reverse();
 
     const cssProps = {

--- a/app/components/pages/MapsPage.js
+++ b/app/components/pages/MapsPage.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import get from 'lodash/get';
 
 import { mapListToQueryString } from 'utils/maps';
 import MapsListContainer from 'containers/maps/MapsListContainer';

--- a/app/components/pages/MapsPage.js
+++ b/app/components/pages/MapsPage.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import get from 'lodash/get';
+
+import { mapListToQueryString } from 'utils/maps';
 import MapsListContainer from 'containers/maps/MapsListContainer';
 import Button from 'components/common/Button';
 import BasicMap from 'containers/maps/BasicMap';
@@ -25,7 +28,7 @@ class MapsPage extends React.Component {
   }
 
   componentDidMount() {
-    const { query, params } = this.context.location;
+    const { query, params, search } = this.context.location;
 
     if (query && query.maps) {
       this.props.saveParamsFromURL(query.maps, params);
@@ -35,11 +38,30 @@ class MapsPage extends React.Component {
         this.props.initializeMaps();
       }
     } else {
-      this.props.updateURL();
+      const queryFromMaps = mapListToQueryString(this.props.maps);
+
+      // meaning we want to load new maps not use cached ones
+      if (!!search && search !== queryFromMaps) {
+        this.props.initializeMaps();
+      } else {
+        this.props.updateURL();
+      }
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps, nextContext) {
+    // // map params has been changed in URL
+    if (nextProps.maps.length && nextContext.location.search) {
+      const queryFromMaps = mapListToQueryString(nextProps.maps);
+      const queryInURL = nextContext.location.search;
+
+      if (queryFromMaps !== queryInURL) {
+        const { query, params } = nextContext.location;
+        nextProps.saveParamsFromURL(query.maps, params);
+        this.props.initializeMaps();
+      }
+    }
+
     if (nextProps.maps.length === 0) {
       this.setMapModal(true);
     } else {

--- a/app/constants/colors.js
+++ b/app/constants/colors.js
@@ -1,23 +1,5 @@
 /* eslint-disable quote-props */
-import chroma from 'chroma-js';
-
-function generateColorScale(colors) {
-  return chroma.bezier(colors)
-    .scale()
-    .correctLightness();
-}
-
-function generateScheme(...colors) {
-  return (nColors) => generateColorScale(colors).colors(nColors);
-}
-
-export const categoryColorScheme = {
-  'bd': generateScheme('#F887F0', '#832685'),
-  'w': generateScheme('#B3ECDD', '#383E9C'),
-  'eco': generateScheme('#9DE644', '#00666B'),
-  'ag': generateScheme('#FFF452', '#509131'),
-  'cl': generateScheme('#FFF780', '#93001C')
-};
+import { generateScheme } from 'utils/colors';
 
 export const modelColors = [
   '#d36060',
@@ -25,9 +7,3 @@ export const modelColors = [
   '#8d43da',
   '#fbd24c'
 ];
-
-// export const summaryLineColors = {
-//   min: '#FCE64D',
-//   mean: '#F29C30',
-//   max: '#DD4414'
-// };

--- a/app/constants/colors.js
+++ b/app/constants/colors.js
@@ -1,6 +1,4 @@
 /* eslint-disable quote-props */
-import { generateScheme } from 'utils/colors';
-
 export const modelColors = [
   '#d36060',
   '#6bdfa1',

--- a/app/containers/pages/MapsPage.js
+++ b/app/containers/pages/MapsPage.js
@@ -7,16 +7,10 @@ const mapStateToProps = state => ({
   config: state.config
 });
 
-const mapDispatchToProps = dispatch => ({
-  saveParamsFromURL: (mapParams, mapConfig) => {
-    dispatch(saveParamsFromURL(mapParams, mapConfig));
-  },
-  initializeMaps: () => {
-    dispatch(initializeMaps());
-  },
-  updateURL: () => {
-    dispatch(updateURL());
-  }
-});
+const mapDispatchToProps = {
+  saveParamsFromURL,
+  initializeMaps,
+  updateURL
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(MapsPage);

--- a/app/styles/components/common/c-display-chart.pcss
+++ b/app/styles/components/common/c-display-chart.pcss
@@ -58,7 +58,6 @@
     .c-step-selector {
       max-width: 240px;
       margin: auto;
-      padding-top: 20px;
       padding-right: 40px;
     }
 

--- a/app/styles/components/common/c-display-chart.pcss
+++ b/app/styles/components/common/c-display-chart.pcss
@@ -11,11 +11,32 @@
     justify-content: space-between;
     align-items: center;
 
+    .title {
+      margin-bottom: 10px;
+      display: flex;
+      align-items: center;
+
+      .map-view-link {
+        text-decoration: inherit;
+        font-family: $font-heading;
+        font-size: $font-size;
+        color: $color-main;
+        cursor: pointer;
+        border-bottom: solid 3px transparent;
+        margin-top: 3px;
+        margin-left: 5px;
+
+        &:hover {
+          border-bottom: solid 3px $color-main;
+        }
+      }
+    }
+
     .c-react-select {
       width: auto;
       min-width: 300px;
-      margin-bottom: 10px;
-      margin-right: 40px;
+      margin-bottom: 0;
+      margin-right: 0;
 
       .Select-menu-outer {
         text-align: left;

--- a/app/utils/charts.js
+++ b/app/utils/charts.js
@@ -2,7 +2,7 @@ import get from 'lodash/get';
 import uniq from 'lodash/uniqBy';
 import flatMap from 'lodash/flatMap';
 import flatten from 'lodash/flatten';
-import { categoryColorScheme } from 'constants/colors';
+import { getColorScheme } from './colors';
 
 function removeLastDot(str) {
   return str.replace(/\.\s*$/, '');
@@ -97,7 +97,7 @@ function getSummaryCharts(category) {
       slug: 'temperature_summary',
       label: 'Average Temperature - Summary (°C)',
       mapViewLink: '/global-scenarios/0/0/3?maps=1.5,cl,ts',
-      colors: categoryColorScheme[category.slug](3),
+      colors: getColorScheme(category.slug, null, 3),
       info: temperatureSummaryInfo
     });
   }
@@ -111,7 +111,7 @@ function getSummaryCharts(category) {
       label: `${i.name} - Summary (${i.unit})`,
       variable: i.slug,
       mapViewLink: `/global-scenarios/0/0/3?maps=1.5,${category.slug},${i.slug}`,
-      colors: categoryColorScheme[category.slug](3),
+      colors: getColorScheme(category.slug, i.slug, 3),
       info: climatologicalSummaryInfo.bind(null, i)
     })));
 

--- a/app/utils/charts.js
+++ b/app/utils/charts.js
@@ -84,6 +84,7 @@ function getClimatologicalCharts(category) {
     measurements: i.measurements,
     label: `${i.name} (${i.unit})`,
     variable: i.slug,
+    mapViewLink: `/global-scenarios/0/0/3?maps=1.5,${category.slug},${i.slug}`,
     info: climatologicalDynamicInfo.bind(null, i)
   }));
 }
@@ -95,6 +96,7 @@ function getSummaryCharts(category) {
     charts.push({
       slug: 'temperature_summary',
       label: 'Average Temperature - Summary (°C)',
+      mapViewLink: '/global-scenarios/0/0/3?maps=1.5,cl,ts',
       colors: categoryColorScheme[category.slug](3),
       info: temperatureSummaryInfo
     });
@@ -108,6 +110,7 @@ function getSummaryCharts(category) {
       slug: `${i.slug}_summary`,
       label: `${i.name} - Summary (${i.unit})`,
       variable: i.slug,
+      mapViewLink: `/global-scenarios/0/0/3?maps=1.5,${category.slug},${i.slug}`,
       colors: categoryColorScheme[category.slug](3),
       info: climatologicalSummaryInfo.bind(null, i)
     })));

--- a/app/utils/colors.js
+++ b/app/utils/colors.js
@@ -1,0 +1,30 @@
+/* eslint-disable quote-props */
+import chroma from 'chroma-js';
+
+function generateColorScale(colors) {
+  return chroma.bezier(colors)
+    .scale()
+    .correctLightness();
+}
+
+function generateScheme(...colors) {
+  return (nColors) => generateColorScale(colors).colors(nColors);
+}
+
+const categoryColorScheme = {
+  'bd': generateScheme('#F887F0', '#832685'),
+  'w': generateScheme('#B3ECDD', '#383E9C'),
+  'eco': generateScheme('#9DE644', '#00666B'),
+  'ag': generateScheme('#FFF452', '#509131'),
+  'cl': generateScheme('#FFF780', '#93001C')
+};
+
+const indicatorColorSchemeOverride = {
+  'pr': generateScheme('#D6ECFC', '#3E39A1')
+};
+
+export function getColorScheme(category, indicator, nColors) {
+  return (
+    indicatorColorSchemeOverride[indicator] || categoryColorScheme[category]
+  )(nColors);
+}

--- a/app/utils/maps.js
+++ b/app/utils/maps.js
@@ -1,0 +1,11 @@
+import trimEnd from 'lodash/trimEnd';
+
+export function mapListToQueryString(mapList) {
+  if (!mapList.length) return '';
+
+  const query = mapList.reduce((q, map) => (
+    `${q}${map.scenario.slug},${map.category.slug},${map.indicator.slug}/`
+  ), '?maps=');
+
+  return trimEnd(query, '/');
+}

--- a/resources/data_management/import_metadata/import.js
+++ b/resources/data_management/import_metadata/import.js
@@ -3,7 +3,7 @@
 const fetch = require('node-fetch');
 const colors = require('cli-colors');
 
-const cartodb = require('./cartodb.json');
+const cartodb = require('./cartodb.json'); // eslint-disable-line import/no-unresolved
 const metadata = require('./metadata.js');
 
 const DEFAULT_COLORSCHEME = ['#FFEEAE', '#FFB148', '#FF8324', '#F54B21', '#D90A54', '#8700AE'];


### PR DESCRIPTION
New "Map View" link for charts which loads map view for chart's category and indicator.

![image](https://user-images.githubusercontent.com/1286444/36032515-906eaea2-0dae-11e8-98b6-227a41445624.png)

This PR also fixes navigation/routing issues with Map page. Browser's back and forward buttons didn't work so you couldn't load the previous/next map for different category or indicator.

What's more, I've spotted that precipitation had different color scheme than the rest of indicators from climate category so I've changed it back to the old one.
![image](https://user-images.githubusercontent.com/1286444/36032890-afb09586-0daf-11e8-85b1-2ab8625d283d.png)
